### PR TITLE
New gear ui elements

### DIFF
--- a/wt-betty/MainWindow.xaml
+++ b/wt-betty/MainWindow.xaml
@@ -5,7 +5,10 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:wt_betty"
         mc:Ignorable="d"
-        Title="WT-Betty v1.2 (ZdrytchX's Fork)" Height="342.763" Width="400" ResizeMode="CanMinimize" Closing="Window_Closing" Loaded="Window_Loaded">
+        Title="WT-Betty v1.2 (ZdrytchX's Fork)" Height="343" Width="400" ResizeMode="CanMinimize" Closing="Window_Closing" Loaded="Window_Loaded">
+    <Window.Resources>
+        <local:kphTomphConversion x:Key="kphTomphConversion"/>
+    </Window.Resources>
     <Grid Margin="0,0,11,11">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="129*"/>
@@ -26,8 +29,8 @@
             <TabItem Header="Options" Background="{x:Null}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="15*"/>
-                        <ColumnDefinition Width="593*"/>
+                        <ColumnDefinition Width="15"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="35"/>
@@ -50,10 +53,14 @@
                     <CheckBox x:Name="cbx_fuel" Content="Bingo Fuel Warning" HorizontalAlignment="Left" Margin="0,10,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="3"/>
 
                     <CheckBox x:Name="cbx_gear" Content="Gear" HorizontalAlignment="Left" Margin="0,10,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="4"/>
-                    <Label x:Name="label_gearDown" Content="Gear Down Threshold" Margin="164,5,55,0" Grid.Column="1" Height="26" VerticalAlignment="Top" Grid.Row="4"/>
-                    <TextBox x:Name="tbx_geardown" Margin="305,5,10,0" TextWrapping="Wrap" Grid.Column="1" Height="23" VerticalAlignment="Top" Grid.Row="4"/>
-                    <Label x:Name="label_gearUp" Content="Gear Up Threshold" Margin="164,34,55,0" Grid.Column="1" Height="26" VerticalAlignment="Top" Grid.Row="4"/>
-                    <TextBox x:Name="tbx_gearup" Margin="305,34,10,0" TextWrapping="Wrap" Grid.Column="1" Height="23" VerticalAlignment="Top" Grid.Row="4"/>
+                    <Label x:Name="label_gearDown" Content="Gear Down Threshold" Margin="105,5,0,0" Grid.Column="1" Grid.Row="4" Height="26" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    <TextBox x:Name="tbx_gearDown" Margin="0,5,75,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="4" Width="30" Height="23" VerticalAlignment="Top" HorizontalAlignment="Right" MaxLines="1" MaxLength="3" Text="999"/>
+                    <Label x:Name="label_gearDown_kph" Content="kph" Grid.Column="1" Grid.Row="4" Margin="0,5,48,0" VerticalAlignment="Top" Padding="1,5,5,0" Height="23" HorizontalAlignment="Right"/>
+                    <Label x:Name="label_gearDown_mph" Content="{Binding Text, Converter={StaticResource kphTomphConversion}, ElementName=tbx_gearDown, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.Row="4" HorizontalAlignment="Right" Margin="0,5,3,0" VerticalAlignment="Top" Padding="1,5,1,0" Height="23"/>
+                    <Label x:Name="label_gearUp" Content="Gear Up Threshold" Margin="105,35,0,0" Grid.Column="1" Grid.Row="4" Height="26" VerticalAlignment="Top"/>
+                    <TextBox x:Name="tbx_gearUp" Margin="0,35,75,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="4" Width="30" Height="23" VerticalAlignment="Top" HorizontalAlignment="Right" MaxLines="1" MaxLength="3" Text="999"/>
+                    <Label x:Name="label_gearUp_kph" Content="kph" Grid.Column="1" Grid.Row="4" Margin="0,35,48,0" VerticalAlignment="Top" Padding="1,5,5,0" Height="23" HorizontalAlignment="Right"/>
+                    <Label x:Name="label_gearUp_mph" Content="{Binding Text, Converter={StaticResource kphTomphConversion}, ElementName=tbx_gearUp, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.Row="4" HorizontalAlignment="Right" Margin="0,35,3,0" VerticalAlignment="Top" Padding="1,5,1,0" Height="23"/>
 
                     <Button x:Name="button_save" Content="Save Settings" Grid.Column="1" Grid.Row="5" Margin="0,0,10,10" HorizontalAlignment="Right" Width="86" Height="20" VerticalAlignment="Bottom" Click="button_save_Click"/>
                     <Button x:Name="button_reset" Content="Reset" HorizontalAlignment="Left" Margin="1,0,0,10" Width="75" Grid.Column="1" Grid.Row="5" Click="button_reset_Click" Height="20" VerticalAlignment="Bottom"/>

--- a/wt-betty/MainWindow.xaml.cs
+++ b/wt-betty/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Threading;
 using System.Globalization;
 using System.Windows.Documents;
 using System.IO;
+using System.Windows.Data;
 
 namespace wt_betty
 {
@@ -44,8 +45,8 @@ namespace wt_betty
             cbx_pullup.IsChecked = User.Default.EnablePullUp;
             cbx_fuel.IsChecked = User.Default.EnableFuel;
             cbx_gear.IsChecked = User.Default.EnableGear;
-            tbx_geardown.Text = User.Default.GearDown.ToString();
-            tbx_gearup.Text = User.Default.GearUp.ToString();
+            tbx_gearDown.Text = User.Default.GearDown.ToString();
+            tbx_gearUp.Text = User.Default.GearUp.ToString();
 
             dispatcherTimer1.Tick += new EventHandler(dispatcherTimer1_Tick);
             dispatcherTimer1.Interval = new TimeSpan(0, 0, 0, 0, 200);
@@ -285,8 +286,8 @@ namespace wt_betty
                 User.Default.EnablePullUp = cbx_pullup.IsChecked.Value;
                 User.Default.EnableFuel = cbx_fuel.IsChecked.Value;
                 User.Default.EnableGear = cbx_gear.IsChecked.Value;
-                User.Default.GearDown = Convert.ToInt32(tbx_geardown.Text);
-                User.Default.GearUp = Convert.ToInt32(tbx_gearup.Text);
+                User.Default.GearDown = Convert.ToInt32(tbx_gearDown.Text);
+                User.Default.GearUp = Convert.ToInt32(tbx_gearUp.Text);
                 User.Default.Save();
             }
             catch (Exception ex)
@@ -319,8 +320,8 @@ namespace wt_betty
                 cbx_pullup.IsChecked = User.Default.EnablePullUp;
                 cbx_fuel.IsChecked = User.Default.EnableFuel;
                 cbx_gear.IsChecked = User.Default.EnableGear;
-                tbx_geardown.Text = User.Default.GearDown.ToString();
-                tbx_gearup.Text = User.Default.GearUp.ToString();
+                tbx_gearDown.Text = User.Default.GearDown.ToString();
+                tbx_gearUp.Text = User.Default.GearUp.ToString();
             }
             catch (Exception ex)
             {
@@ -333,6 +334,29 @@ namespace wt_betty
             var helpFile = Path.Combine(Path.GetTempPath(), "wt-betty-help.txt");
             File.WriteAllText(helpFile, Properties.Resources.wt_betty_help);
             System.Diagnostics.Process.Start(helpFile);
+        }
+    }
+
+    public class kphTomphConversion : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                int kph = System.Convert.ToInt32(value.ToString());
+                double mph = kph / 1.609;
+                String mph_rounded = String.Format("{0:0}", Math.Truncate(mph * 10) / 10) + "mph";
+                return mph_rounded;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+                return "ERROR";
+            }
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return false;
         }
     }
 }

--- a/wt-betty/MainWindow.xaml.cs
+++ b/wt-betty/MainWindow.xaml.cs
@@ -130,8 +130,8 @@ namespace wt_betty
             {
                 myIndicator = JsonSerializer._download_serialized_json_data<indicator>(indicatorsurl);
                 myState = JsonSerializer._download_serialized_json_data<state>(statesurl);
-                
-                if (myState.valid == "true")
+
+                if ((myState.valid == "true") && (myIndicator.valid == "true") && (myIndicator.type != "dummy_plane") && (myIndicator.type != null))
                 {
 
                     decimal G = Convert.ToDecimal(myState.Ny, culture);


### PR DESCRIPTION
Additions:
Added 2 labels displaying mph conversion for gear up/down warning.
Added length and line restrictions to both text boxes.
Added new rules for getData() to avoid unintended warning before spawn:
No warning would be played if myIndicator is invalid or the plane is 'dummy_plane' or null.

Changes:
The width of Column0 inside ColumnDefinition of Option tab changed from "15*" to "15".
The width of Column1 of said ColumnDefinition changed from "593*" to "*".
Changed window height to 343px.
Renamed tbx_geardown to tbx_gearDown and tbx_gearup to tbx_gearUp.